### PR TITLE
[monitor] add timestamp to status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.0
+
+### Added
+- `ChangedAt` and `Duration` fields exposed in message templates (online, offline, services_list)
+- Timestamp tracking of state transitions in the `/status` command
+
 ## v1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ The bot uses a flexible template system for customizing notification messages. T
 
 Available templates:
 
-| Template        | Variables                                                                                                                | Description                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
-| `online`        | `Name` - name of the service                                                                                             | message when a service goes "online"  |
-| `offline`       | `Name` - name of the service<br>`Error` - error message                                                                  | message when a service goes "offline" |
-| `services_list` | `.` - list of all services:<br>`Name` - name of the service<br>`State` - state of the service<br>`Error` - error message | message with a list of all services   |
+| Template        | Variables                                                                                                                                                                                                                                 | Description                           |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `online`        | `Name` - name of the service<br>`ChangedAt` - when the service entered this state<br>`Duration` - how long the service has been in this state                                                                                             | message when a service goes "online"  |
+| `offline`       | `Name` - name of the service<br>`Error` - error message<br>`ChangedAt` - when the service entered this state<br>`Duration` - how long the service has been in this state                                                                  | message when a service goes "offline" |
+| `services_list` | `.` - list of all services:<br>`Name` - name of the service<br>`State` - state of the service<br>`Error` - error message<br>`ChangedAt` - when the service entered this state<br>`Duration` - how long the service has been in this state | message with a list of all services   |
 
 ### Commands
 

--- a/internal/bot/service.go
+++ b/internal/bot/service.go
@@ -47,19 +47,25 @@ func (s *Service) Run(ctx context.Context) error {
 	for v := range ch {
 		s.logger.Debug("probe", zap.String("name", v.Name), zap.String("state", string(v.State)), zap.Error(v.Error))
 
+		duration := messages.FormatDurationSince(v.ChangedAt)
+
 		var msg string
 		if v.State == monitor.ServiceStateOffline {
 			msg, err = s.messages.Offline(
 				messages.OfflineContext{
 					OnlineContext: messages.OnlineContext{
-						Name: v.Name,
+						Name:      v.Name,
+						ChangedAt: v.ChangedAt,
+						Duration:  duration,
 					},
 					Error: v.Error.Error(),
 				},
 			)
 		} else {
 			msg, err = s.messages.Online(messages.OnlineContext{
-				Name: v.Name,
+				Name:      v.Name,
+				ChangedAt: v.ChangedAt,
+				Duration:  duration,
 			})
 		}
 
@@ -96,7 +102,7 @@ func (s *Service) HandleStatusCommand(_ context.Context, cmd telegram.Command) {
 	context := make(messages.ServicesListContext, len(services))
 
 	for i, service := range services {
-		context[i] = messages.NewServiceState(service.Name, string(service.State), service.Error)
+		context[i] = messages.NewServiceState(service.Name, string(service.State), service.Error, service.ChangedAt)
 	}
 
 	msg, err := s.messages.ServicesList(context)

--- a/internal/messages/defaults.go
+++ b/internal/messages/defaults.go
@@ -5,6 +5,6 @@ func defaultTemplates() map[string]string {
 	return map[string]string{
 		TemplateOnline:       "✅ {{.Name | escape}} is *online*",
 		TemplateOffline:      "❌ {{.Name | escape}} is *offline*: {{.Error | escape}}",
-		TemplateServicesList: "📋 Services:\n\n{{range .}}\\- {{.Name | escape}}: {{if eq .State \"online\"}}✅{{else}}❌{{with .Error}} \\({{. | escape}}\\){{end}}{{end}}\n{{end}}",
+		TemplateServicesList: "📋 Services:\n\n{{range .}}\\- {{.Name | escape}}: {{if eq .State \"online\"}}✅ \\({{.Duration}}\\){{else}}❌ \\({{.Duration}}\\){{with .Error}} \\({{. | escape}}\\){{end}}{{end}}\n{{end}}",
 	}
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,5 +1,9 @@
 package messages
 
+import (
+	"time"
+)
+
 const (
 	TemplateOnline       string = "online"
 	TemplateOffline      string = "offline"
@@ -7,7 +11,9 @@ const (
 )
 
 type OnlineContext struct {
-	Name string
+	Name      string
+	ChangedAt time.Time
+	Duration  string
 }
 
 type OfflineContext struct {
@@ -17,22 +23,35 @@ type OfflineContext struct {
 }
 
 type ServiceState struct {
-	Name  string
-	State string
-	Error string
+	Name      string
+	State     string
+	Error     string
+	ChangedAt time.Time
+	Duration  string
 }
 
-func NewServiceState(name, state string, err error) ServiceState {
+func NewServiceState(name, state string, err error, changedAt time.Time) ServiceState {
 	errStr := ""
 	if err != nil {
 		errStr = err.Error()
 	}
 
+	duration := FormatDurationSince(changedAt)
+
 	return ServiceState{
-		Name:  name,
-		State: state,
-		Error: errStr,
+		Name:      name,
+		State:     state,
+		Error:     errStr,
+		ChangedAt: changedAt,
+		Duration:  duration,
 	}
 }
 
 type ServicesListContext []ServiceState
+
+func FormatDurationSince(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	return time.Since(t).Truncate(time.Second).String()
+}

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -128,22 +128,26 @@ func (m *Service) updateState(id int, probe error) *ServiceStatus {
 	if !current.Online && current.Probes == int(service.SuccessThreshold) {
 		current.Online = true
 		current.Error = nil
+		current.ChangedAt = time.Now()
 
 		upd = &ServiceStatus{
-			ID:    service.ID,
-			Name:  service.Name,
-			State: ServiceStateOnline,
-			Error: nil,
+			ID:        service.ID,
+			Name:      service.Name,
+			State:     ServiceStateOnline,
+			Error:     nil,
+			ChangedAt: current.ChangedAt,
 		}
 	} else if current.Online && current.Probes == -int(service.FailureThreshold) {
 		current.Online = false
 		current.Error = probe
+		current.ChangedAt = time.Now()
 
 		upd = &ServiceStatus{
-			ID:    service.ID,
-			Name:  service.Name,
-			State: ServiceStateOffline,
-			Error: probe,
+			ID:        service.ID,
+			Name:      service.Name,
+			State:     ServiceStateOffline,
+			Error:     probe,
+			ChangedAt: current.ChangedAt,
 		}
 	}
 
@@ -166,10 +170,11 @@ func (m *Service) GetCurrentStatuses() []ServiceStatus {
 	for i, service := range m.services {
 		state := m.states[i]
 		statuses[i] = ServiceStatus{
-			ID:    service.ID,
-			Name:  service.Name,
-			State: state.State(),
-			Error: state.Error,
+			ID:        service.ID,
+			Name:      service.Name,
+			State:     state.State(),
+			Error:     state.Error,
+			ChangedAt: state.ChangedAt,
 		}
 	}
 

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -18,10 +18,11 @@ type Probeer interface {
 }
 
 type ServiceStatus struct {
-	ID    string
-	Name  string
-	State ServiceState
-	Error error
+	ID        string
+	Name      string
+	State     ServiceState
+	Error     error
+	ChangedAt time.Time
 }
 
 type state struct {
@@ -29,6 +30,7 @@ type state struct {
 	Online    bool
 	Error     error
 	Timestamp time.Time
+	ChangedAt time.Time
 }
 
 func (s state) State() ServiceState {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message templates now expose `ChangedAt` and a human-friendly `Duration` for online/offline events and each entry in the services list.
  * The `/status` output now includes per-service transition timestamps so durations can be shown.
* **Documentation**
  * Updated the README “Messages Template System” table to document the new timestamp/duration variables.
  * Added a v1.3.0 changelog entry describing the new fields.
* **Bug Fixes**
  * Refined the default services-list template formatting, including consistent optional error rendering and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->