### PR TITLE
[monitor] improve errors reporting

### DIFF
--- a/internal/monitor/probes/http.go
+++ b/internal/monitor/probes/http.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 type HTTPGet struct {
@@ -33,9 +34,10 @@ func (p *HTTPGet) Probe(ctx context.Context) error {
 
 	req.Header = p.Config.HTTPHeaders
 
+	start := time.Now()
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInfrastructureError, err)
+		return fmt.Errorf("%w after %s: %w", ErrInfrastructureError, time.Since(start), err)
 	}
 
 	defer func() {
@@ -44,7 +46,15 @@ func (p *HTTPGet) Probe(ctx context.Context) error {
 	}()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf("%w: status %d", ErrResponseError, resp.StatusCode)
+		const maxBodyLen = 512
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyLen))
+		return fmt.Errorf(
+			"%w: status %d, body %q, duration %s",
+			ErrResponseError,
+			resp.StatusCode,
+			string(bodyBytes),
+			time.Since(start),
+		)
 	}
 
 	return nil

--- a/internal/monitor/probes/tcp.go
+++ b/internal/monitor/probes/tcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 )
 
 type TCPSocket struct {
@@ -20,9 +21,10 @@ func NewTCPSocket(cfg TCPSocketConfig) *TCPSocket {
 }
 
 func (p *TCPSocket) Probe(ctx context.Context) error {
+	start := time.Now()
 	conn, err := p.dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", p.Config.Host, p.Config.Port))
 	if err != nil {
-		return fmt.Errorf("failed to dial: %w", err)
+		return fmt.Errorf("failed to dial after %s: %w", time.Since(start), err)
 	}
 
 	_ = conn.Close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP probes now include precise request duration and, for bad HTTP responses (status ≥ 400), capture a short response body snippet to provide more actionable error details.
  * TCP connection probes now report how long dialing took when connection attempts fail, improving diagnostics for infrastructure/network issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->