### PR TITLE
[config] set default telegram client timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,7 @@ func Default() Config {
 		Telegram: telegramConfig{
 			Token:    "",
 			ProxyURL: "",
-			Timeout:  0,
+			Timeout:  time.Minute,
 			ChatID:   0,
 			Debug:    false,
 			Messages: TelegramMessages{},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default Telegram timeout configuration to prevent indefinite operation hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->